### PR TITLE
Fix test for upcoming ggplot2 update

### DIFF
--- a/tests/testthat/test-ggplot.R
+++ b/tests/testthat/test-ggplot.R
@@ -1,10 +1,11 @@
 test_that("ggplot creation works", {
+  expected_length <- length(ggplot2::ggplot())
   lapply(
     1:100, function(x){
       a <- random_ggplot()
       expect_is(a, "gg")
       expect_is(a, "ggplot")
-      expect_length(a, 9)
+      expect_length(a, expected_length)
     }
   )
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break shinipsum.

Briefly, testing that the length of a ggplot object is length 9 is brittle for changes in ggplot2 itself. This PR updates the expectation of the test to the lame length as a ggplot object, rather than exactly 9.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help shinipsum get out a fix if necessary.